### PR TITLE
Add task_key field to sTaskRun

### DIFF
--- a/_bootstrap/index.php
+++ b/_bootstrap/index.php
@@ -114,6 +114,10 @@ foreach ($objectContainers as $oC) {
     $manager->createObjectContainer($oC);
 }
 
+/* 2021-02-15 - add field/index for sTaskRun->task_key */
+$manager->addField('sTaskRun', 'task_key');
+$manager->addIndex('sTaskRun', 'task_key');
+
 $modx->getCacheManager()->refresh();
 echo "Done.\n";
 

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -8,7 +8,7 @@ if (!defined('MOREPROVIDER_BUILD')) {
     /* define version */
     define('PKG_NAME','Scheduler');
     define('PKG_NAME_LOWER',strtolower(PKG_NAME));
-    define('PKG_VERSION','1.3.0');
+    define('PKG_VERSION','1.2.1');
     define('PKG_RELEASE','pl');
 
     /* load modx */

--- a/_build/resolvers/resolve.dbchanges.php
+++ b/_build/resolvers/resolve.dbchanges.php
@@ -18,6 +18,9 @@ switch($options[xPDOTransport::PACKAGE_ACTION]) {
         $modx->setLogLevel(0);
 
         // changes here
+        /* 2021-02-15 - add field/index for sTaskRun->task_key */
+        $manager->addField('sTaskRun', 'task_key');
+        $manager->addIndex('sTaskRun', 'task_key');
 
         // set back console logging
         $modx->setLogLevel($oldLogLevel);

--- a/assets/components/scheduler/js/mgr/widgets/grid.future.js
+++ b/assets/components/scheduler/js/mgr/widgets/grid.future.js
@@ -15,6 +15,7 @@ Scheduler.grid.Future = function(config) {
             ,{ name: 'task', type: 'string' }
             ,{ name: 'task_namespace', type: 'string' }
             ,{ name: 'task_reference', type: 'string' }
+            ,{ name: 'task_key', type: 'string' }
             ,{ name: 'task_content', type: 'string' }
             ,{ name: 'task_description', type: 'string' }
             ,{ name: 'timing', type: 'date', dateFormat: 'U' }
@@ -34,6 +35,12 @@ Scheduler.grid.Future = function(config) {
 			,width: 50
             ,hidden: true
 		},{
+            header: _('scheduler.task_key')
+            ,dataIndex: 'task_key'
+            ,sortable: true
+            ,width: 50
+            ,hidden: true
+        },{
 			header: _('scheduler.task')
 			,dataIndex: 'task'
 			,sortable: true

--- a/assets/components/scheduler/js/mgr/widgets/grid.history.js
+++ b/assets/components/scheduler/js/mgr/widgets/grid.history.js
@@ -15,6 +15,7 @@ Scheduler.grid.History = function(config) {
             ,{ name: 'task_content', type: 'string' }
             ,{ name: 'task_namespace', type: 'string' }
             ,{ name: 'task_reference', type: 'string' }
+            ,{ name: 'task_key', type: 'string' }
             ,{ name: 'task_description', type: 'string' }
             ,{ name: 'id', type: 'int' }
             ,{ name: 'status', type: 'int' }
@@ -33,6 +34,12 @@ Scheduler.grid.History = function(config) {
 			,width: 50
             ,hidden: true
 		},{
+            header: _('scheduler.task_key')
+            ,dataIndex: 'task_key'
+            ,sortable: true
+            ,width: 50
+            ,hidden: true
+        },{
 			header: _('scheduler.task')
 			,dataIndex: 'task'
 			,sortable: true

--- a/assets/components/scheduler/js/mgr/widgets/windows.future.js
+++ b/assets/components/scheduler/js/mgr/widgets/windows.future.js
@@ -68,6 +68,11 @@ Scheduler.window.CreateRun = function(config) {
             ,cls: 'desc-under'
             ,style: 'padding-top: 5px;'
         },{
+            xtype: 'textfield'
+            ,name: 'task_key'
+            ,fieldLabel: _('scheduler.task_key')
+            ,anchor: '100%'
+        },{
             xtype: 'scheduler-grid-future-run-localdata'
             ,id: 'scheduler-grid-future-run-localdata-'+this.ident
             ,preventRender: true
@@ -135,6 +140,11 @@ Scheduler.window.UpdateRun = function(config) {
             ,fieldLabel: _('scheduler.timing')
             ,anchor: '99%'
             ,allowBlank: true
+        },{
+            xtype: 'textfield'
+            ,name: 'task_key'
+            ,fieldLabel: _('scheduler.task_key')
+            ,anchor: '100%'
         },{
             xtype: 'scheduler-grid-future-run-localdata'
             ,id: 'scheduler-grid-future-run-localdata-'+this.ident

--- a/assets/components/scheduler/js/mgr/widgets/windows.history.js
+++ b/assets/components/scheduler/js/mgr/widgets/windows.history.js
@@ -66,6 +66,11 @@ Scheduler.window.ReScheduleRun = function(config) {
             ,html: _('scheduler.timing.desc')
             ,cls: 'desc-under'
             ,style: 'padding-top: 5px;'
+        },{
+            xtype: 'textfield'
+            ,name: 'task_key'
+            ,fieldLabel: _('scheduler.task_key')
+            ,anchor: '100%'
         }]
 	});
 	Scheduler.window.ReScheduleRun.superclass.constructor.call(this,config);

--- a/core/components/scheduler/docs/changelog.txt
+++ b/core/components/scheduler/docs/changelog.txt
@@ -1,3 +1,11 @@
+Scheduler 1.2.1-pl
+------------------
+Released on 2021-02-xx
+
+- Add task_key field to sTaskRun, to allow setting/searching/indexing of small pieces of data. Among other things,
+  this allows outside extras to retrieve and act on task runs more easily.
+
+
 Scheduler 1.2.0-pl
 ------------------
 Released on 2020-01-03

--- a/core/components/scheduler/lexicon/en/default.inc.php
+++ b/core/components/scheduler/lexicon/en/default.inc.php
@@ -30,6 +30,7 @@ $_lang['scheduler.content.processor'] = "The name of the processor";
 $_lang['scheduler.content.processor_desc'] = "Enter the name of the processor which should be executed each run. This is relative to the processors folder inside the selected namespace and without (.class).php extension.";
 $_lang['scheduler.namespace'] = "Namespace";
 $_lang['scheduler.reference'] = "Reference";
+$_lang['scheduler.task_key'] = "Task key";
 $_lang['scheduler.description'] = "Description";
 $_lang['scheduler.status'] = "Status";
 $_lang['scheduler.task'] = "Task";

--- a/core/components/scheduler/model/scheduler/mysql/sfiletask.map.inc.php
+++ b/core/components/scheduler/model/scheduler/mysql/sfiletask.map.inc.php
@@ -3,6 +3,10 @@ $xpdo_meta_map['sFileTask']= array (
   'package' => 'scheduler',
   'version' => '1.1',
   'extends' => 'sTask',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
   ),

--- a/core/components/scheduler/model/scheduler/mysql/sprocessortask.map.inc.php
+++ b/core/components/scheduler/model/scheduler/mysql/sprocessortask.map.inc.php
@@ -3,6 +3,10 @@ $xpdo_meta_map['sProcessorTask']= array (
   'package' => 'scheduler',
   'version' => '1.1',
   'extends' => 'sTask',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
   ),

--- a/core/components/scheduler/model/scheduler/mysql/ssnippettask.map.inc.php
+++ b/core/components/scheduler/model/scheduler/mysql/ssnippettask.map.inc.php
@@ -3,6 +3,10 @@ $xpdo_meta_map['sSnippetTask']= array (
   'package' => 'scheduler',
   'version' => '1.1',
   'extends' => 'sTask',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
   ),

--- a/core/components/scheduler/model/scheduler/mysql/stask.map.inc.php
+++ b/core/components/scheduler/model/scheduler/mysql/stask.map.inc.php
@@ -3,6 +3,10 @@ $xpdo_meta_map['sTask']= array (
   'package' => 'scheduler',
   'version' => '1.1',
   'table' => 'scheduler_task',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
     'class_key' => 'sSnippetTask',

--- a/core/components/scheduler/model/scheduler/mysql/staskrun.map.inc.php
+++ b/core/components/scheduler/model/scheduler/mysql/staskrun.map.inc.php
@@ -3,12 +3,17 @@ $xpdo_meta_map['sTaskRun']= array (
   'package' => 'scheduler',
   'version' => '1.1',
   'table' => 'scheduler_run',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
     'status' => 0,
     'task' => 0,
     'timing' => 0,
     'data' => NULL,
+    'task_key' => '',
     'executedon' => NULL,
     'errors' => NULL,
     'message' => NULL,
@@ -45,6 +50,14 @@ $xpdo_meta_map['sTaskRun']= array (
       'phptype' => 'array',
       'null' => true,
     ),
+    'task_key' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '128',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
     'executedon' => 
     array (
       'dbtype' => 'int',
@@ -63,6 +76,25 @@ $xpdo_meta_map['sTaskRun']= array (
       'dbtype' => 'text',
       'phptype' => 'string',
       'null' => true,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'task_key' => 
+    array (
+      'alias' => 'task_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'task_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
     ),
   ),
   'aggregates' => 

--- a/core/components/scheduler/model/schema/scheduler.mysql.schema.xml
+++ b/core/components/scheduler/model/schema/scheduler.mysql.schema.xml
@@ -28,6 +28,8 @@
         <field key="timing" dbtype="int" precision="20" phptype="int" null="false" default="0" />
         <!-- Data to pass to the task -->
         <field key="data" dbtype="text" phptype="array" null="true" />
+        <!-- optional key to pass to the task run; can be used to look up and modify tasks associated with other modx objects programatically -->
+        <field key="task_key" dbtype="varchar" precision="128" phptype="string" null="false" default="" />
 
         <!-- Results from running the task -->
         <field key="executedon" dbtype="int" precision="20" phptype="int" null="true" />
@@ -35,6 +37,10 @@
         <field key="message" dbtype="text" phptype="string" null="true" />
 
         <aggregate alias="Task" class="sTask" local="task" foreign="id" cardinality="one" owner="foreign" />
+
+        <index alias="task_key" name="task_key" primary="false" unique="false" type="BTREE">
+            <column key="task_key" length="" collation="A" null="false" />
+        </index>
     </object>
 </model>
 

--- a/core/components/scheduler/processors/mgr/runs/future.class.php
+++ b/core/components/scheduler/processors/mgr/runs/future.class.php
@@ -26,7 +26,10 @@ class SchedulerTaskRunFutureListProcessor extends modObjectGetListProcessor {
 
         $query = $this->getProperty('query');
         if(!empty($query)) {
-            $c->andCondition(array('Task.reference:LIKE' => '%'.$query.'%'));
+            $c->where(array(
+              'Task.reference:LIKE' => '%'.$query.'%',
+              'OR:sTaskRun.task_key:LIKE' => '%'.$query.'%',
+            ));
         }
 
         $namespace = $this->getProperty('namespace');

--- a/core/components/scheduler/processors/mgr/runs/reschedule.class.php
+++ b/core/components/scheduler/processors/mgr/runs/reschedule.class.php
@@ -28,6 +28,9 @@ class SchedulerRescheduleTaskRunProcessor extends modObjectDuplicateProcessor {
         if(empty($timing)) { $this->addFieldError('timing', $this->modx->lexicon('scheduler.error.no-timing')); }
         $this->newObject->setTiming($timing, false);
 
+        $taskKey = $this->getProperty('task_key', "");
+        $this->newObject->set('task_key', $taskKey);
+
         return parent::beforeSave();
     }
 }


### PR DESCRIPTION
Add task_key field to sTaskRun, to allow setting/searching/indexing of small pieces of data. Among other things, this allows outside extras to retrieve and act on task runs more easily.

This PR adds the fields to the schema and db and adds an index to the db for the task_key (might also want to add indexes for status and/or task at some point, but that's not really this PR's focus). It also adds the fields to the Future and Historic grids (hidden) and the Create, Update and Reschedule windows. It also adds the task_key to the `where` for the taskrun getlist processor. 

I've tested this locally and didn't run into any issues. 